### PR TITLE
Implemented complex GroupJoin

### DIFF
--- a/src/Atis.LinqToSql.UnitTest/Entities.cs
+++ b/src/Atis.LinqToSql.UnitTest/Entities.cs
@@ -290,4 +290,20 @@ namespace Atis.LinqToSql.UnitTest
         public Func<ItemBase> NavItem { get; set; }
     }
 
+    public class Order
+    {
+        public string OrderID { get; set; }
+        public string CustomerId { get; set; }
+        public DateTime OrderDate { get; set; }
+    }
+
+    public class OrderDetail
+    {
+        public string OrderID { get; set; }
+        public decimal Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+
+    }
+
+
 }

--- a/src/Atis.LinqToSql/ExpressionConverters/ParameterExpressionConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/ParameterExpressionConverter.cs
@@ -97,7 +97,17 @@ namespace Atis.LinqToSql.ExpressionConverters
                     if (scalarVal != null)
                         return scalarVal;
                 }
-                result = new SqlDataSourceReferenceExpression(sqlExpression);
+                if (sqlExpression is SqlDataSourceExpression ds && ds.NodeType == SqlExpressionType.OtherDataSource)
+                {
+                    var otherDataSourceQuery = ds.DataSource as SqlQueryExpression
+                                                ??
+                                                throw new InvalidOperationException($"'{ds.DataSource}' is not a SqlQueryExpression");
+                    // other data source cannot be modified itself, it will always make a copy whenever used
+                    var newSqlQuery = otherDataSourceQuery.CreateCopy(clearModelMaps: true);
+                    result = newSqlQuery;
+                }
+                else
+                    result = new SqlDataSourceReferenceExpression(sqlExpression);
             }
             else
                 result = sqlExpression;

--- a/src/Atis.LinqToSql/ExpressionConverters/QueryMethodExpressionConverterBase.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/QueryMethodExpressionConverterBase.cs
@@ -139,10 +139,14 @@ namespace Atis.LinqToSql.ExpressionConverters
             {
                 SqlQueryExpression sqlQuery = (convertedExpression as SqlDataSourceReferenceExpression)?.DataSource as SqlQueryExpression
                                                 ??
+(                                                (convertedExpression as SqlDataSourceReferenceExpression)?.DataSource as SqlDataSourceExpression)?.DataSource as SqlQueryExpression
+                                                ??
                                                 convertedExpression as SqlQueryExpression;
-
+                
                 if (this.SourceQuery == null)
+                {
                     this.SourceQuery = sqlQuery;
+                }
 
                 if (sqlQuery != null)
                 {

--- a/src/Atis.LinqToSql/ExtensionMethods.cs
+++ b/src/Atis.LinqToSql/ExtensionMethods.cs
@@ -23,6 +23,20 @@ namespace Atis.LinqToSql
             return sqlQuerySource is SqlQueryExpression sqlQuery && sqlQuery.IsTableOnly();
         }
 
+        public static SqlColumnExpression[] GetProjections(this SqlExpression sqlExpression)
+        {
+            if (sqlExpression is SqlColumnExpression sqlColumnExpression)
+            {
+                return new[] { sqlColumnExpression };
+            }
+            else if (sqlExpression is SqlCollectionExpression sqlCollectionExpression)
+            {
+                return sqlCollectionExpression.SqlExpressions.Cast<SqlColumnExpression>().ToArray();
+            }
+            else
+                throw new InvalidOperationException($"Argument '{nameof(sqlExpression)}' must be of type '{nameof(SqlColumnExpression)}' or '{nameof(SqlCollectionExpression)}'.");
+        }
+
         public static bool TryGetScalarColumn(this SqlExpression sqlExpression, out SqlColumnExpression sqlScalarColumn)
         {
             if (sqlExpression is SqlColumnExpression sqlColumnExpression && sqlColumnExpression.NodeType == SqlExpressionType.ScalarColumn)

--- a/src/Atis.LinqToSql/Internal/DebugAliasGenerator.cs
+++ b/src/Atis.LinqToSql/Internal/DebugAliasGenerator.cs
@@ -72,7 +72,22 @@ namespace Atis.LinqToSql.Internal
 
         public static string GetAlias(SqlDataSourceExpression ds)
         {
-            return GetAlias(ds.DataSourceAlias, ds.NodeType == SqlExpressionType.DataSource ? "t" : "t_cte");
+            return GetAlias(ds.DataSourceAlias, GetDataSourceType(ds));
+        }
+
+        private static string GetDataSourceType(SqlDataSourceExpression ds)
+        {
+            switch (ds.NodeType)
+            {
+                case SqlExpressionType.DataSource:
+                    return "t";
+                case SqlExpressionType.CteDataSource:
+                    return "t_cte";
+                case SqlExpressionType.OtherDataSource:
+                    return "t_other";
+                default:
+                    return "t_ds";
+            }
         }
     }
 

--- a/src/Atis.LinqToSql/SqlExpressions/SqlColumnExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlColumnExpression.cs
@@ -84,7 +84,7 @@
         ///         Gets the model path of the column.
         ///     </para>
         /// </summary>
-        public ModelPath ModelPath { get; }
+        public ModelPath ModelPath { get; private set; }
 
         /// <summary>
         ///     <para>
@@ -116,6 +116,11 @@
         protected internal override SqlExpression Accept(SqlExpressionVisitor sqlExpressionVisitor)
         {
             return sqlExpressionVisitor.VisitSqlColumnExpression(this);
+        }
+
+        public void ClearModelPath()
+        {
+            this.ModelPath = new ModelPath(this.ColumnAlias);
         }
 
         // not updating the ModelPath, because we were copying projection elsewhere, so we experienced same

--- a/src/Atis.LinqToSql/SqlExpressions/SqlDataSourceExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlDataSourceExpression.cs
@@ -16,6 +16,7 @@ namespace Atis.LinqToSql.SqlExpressions
             {
                 SqlExpressionType.DataSource,
                 SqlExpressionType.CteDataSource,
+                SqlExpressionType.OtherDataSource,      // this data source will be added because of GroupJoin
             };
         private static SqlExpressionType ValidateNodeType(SqlExpressionType nodeType)
             => _allowedTypes.Contains(nodeType)
@@ -171,6 +172,11 @@ namespace Atis.LinqToSql.SqlExpressions
         public void ReplaceModelPathPrefix(string modelPathPrefix)
         {
             this.AddOrReplaceModelPathPrefix(modelPathPrefix, replace: true);
+        }
+
+        public void ClearModelPath()
+        {
+            this.ModelPath = ModelPath.Empty;
         }
 
         /// <summary>

--- a/src/Atis.LinqToSql/SqlExpressions/SqlExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlExpression.cs
@@ -98,7 +98,9 @@ namespace Atis.LinqToSql.SqlExpressions
         Update,
         Delete,
         Not,
-        CteDataSource
+        CteDataSource,
+        OtherDataSource,
+        OuterApplyQueryColumn
     }
 
 

--- a/src/Atis.LinqToSql/SqlExpressions/SqlOuterApplyQueryColumnExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlOuterApplyQueryColumnExpression.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Atis.LinqToSql.SqlExpressions
+{
+    public class SqlOuterApplyQueryColumnExpression : SqlColumnExpression
+    {
+        public override SqlExpressionType NodeType => SqlExpressionType.OuterApplyQueryColumn;
+
+        // will not visit in this property because it's a reference
+        public SqlQueryExpression OuterApplyQuery { get; }
+
+        public SqlOuterApplyQueryColumnExpression(SqlExpression columnExpression, string columnAlias, ModelPath modelPath, SqlQueryExpression outerApplyQuery) : base(columnExpression, columnAlias, modelPath)
+        {
+            this.OuterApplyQuery = outerApplyQuery;
+        }
+    }
+}


### PR DESCRIPTION
Implemented complex `GroupJoin` where the joined source can be used as sub-query within `Where` and `Select`.

Example:

```csharp
var q = from o in orders
        join od in orderDetails on o.OrderID equals od.OrderID
        join c in customers on o.CustomerId equals c.CustomerId into g
        where g.Count() > 0
        select new { o.OrderID, o.OrderDate, od.Quantity, od.UnitPrice, Count = g.Count() };
```

Translates to:

```sql
select	a_1.OrderID as OrderID, a_1.OrderDate as OrderDate, a_2.Quantity as Quantity, a_2.UnitPrice as UnitPrice, 
            (
		select	Count(1) as Col1
		from	Customer as a_3
		where	(a_1.CustomerId = a_3.CustomerId)
	    ) as Count
from	Order as a_1
		inner join OrderDetail as a_2 on (a_1.OrderID = a_2.OrderID)
where	((
		select	Count(1) as Col1
		from	Customer as a_3
		where	(a_1.CustomerId = a_3.CustomerId)
	) > 0)
```