### PR TITLE
Add Select without From, Date Functions and Sql Keyword support.

### DIFF
--- a/src/Atis.LinqToSql.UnitTest/SqlExpressionTranslator.cs
+++ b/src/Atis.LinqToSql.UnitTest/SqlExpressionTranslator.cs
@@ -116,10 +116,19 @@ namespace Atis.LinqToSql.UnitTest
             {
                 return this.TranslateSqlInValuesExpression(sqlInValuesExpression);
             }
+            else if (sqlExpression is SqlKeywordExpression sqlKeywordExpression)
+            {
+                return this.TranslateSqlKeywordExpression(sqlKeywordExpression);
+            }
             else
             {
                 throw new NotSupportedException($"SqlExpression type '{sqlExpression?.GetType().Name}' is not supported.");
             }
+        }
+
+        private string TranslateSqlKeywordExpression(SqlKeywordExpression sqlKeywordExpression)
+        {
+            return sqlKeywordExpression.Keyword;
         }
 
         private string TranslateSqlInValuesExpression(SqlInValuesExpression sqlInValuesExpression)
@@ -242,7 +251,7 @@ namespace Atis.LinqToSql.UnitTest
                     fromString = this.GetSimpleAlias(sqlQueryExpression.InitialDataSource.DataSourceAlias, sqlQueryExpression.InitialDataSource.Tag);
                 }
             }
-            else
+            else if (sqlQueryExpression.InitialDataSource != null)
             {
                 initialDataSource = this.Translate(sqlQueryExpression.InitialDataSource);
             }
@@ -338,7 +347,8 @@ namespace Atis.LinqToSql.UnitTest
                 string selectPart = string.Empty;
                 if (projectionPart != null)
                     selectPart = $"select{distinct}{topPart}\t{projectionPart}\r\n";
-                query = $"{this.GetExpressionId(sqlQueryExpression.Id)}{selectPart}from\t{initialDataSource}{joins}{wherePart}{groupByPart}{havingPart}{orderByPart}{pagingPart}{unions}";
+                string fromPart = initialDataSource != null ? $"from\t{initialDataSource}" : string.Empty;
+                query = $"{this.GetExpressionId(sqlQueryExpression.Id)}{selectPart}{fromPart}{joins}{wherePart}{groupByPart}{havingPart}{orderByPart}{pagingPart}{unions}";
                 if (projectionPart != null)
                     query = $"(\r\n\t{query.Replace("\r\n", "\r\n\t")}\r\n)";
             }

--- a/src/Atis.LinqToSql.UnitTest/Tests/GeneralTranslationTests.cs
+++ b/src/Atis.LinqToSql.UnitTest/Tests/GeneralTranslationTests.cs
@@ -535,5 +535,93 @@ select	a_1.RowId as RowId, a_1.EmployeeId as EmployeeId, a_1.Name as Name, a_1.D
 ";
             Test("All Method Call Test", q.Expression, expectedResult);
         }
+
+        [TestMethod]
+        public void Direct_Select_method_call()
+        {
+            var q = dbc.Select(() => new { n = 1 })
+                            .Where(x => x.n > 5);
+            string? expectedResult = @"
+select	a_1.n as n
+from	(
+    select	1 as n
+
+) as a_1
+	where	(n > 5)
+";
+            Test("Direct Select Test", q.Expression, expectedResult);
+        }
+
+        [TestMethod]
+        public void Direct_Select_with_recursive_query_to_generate_sequence()
+        {
+            var q = dbc.Select(() => new { n = 1 })
+                           .RecursiveUnion(
+                                anchor => anchor
+                                            .Where(anchorMember => anchorMember.n < 10)
+                                            .Select(anchorMember => new { n = anchorMember.n + 1 })
+                            );
+            string? expectedResult = @"
+with cte_1 as 
+(	
+	select	1 as n	
+	union all	
+	select	(a_2.n + 1) as n	
+	from	cte_1 as a_2	
+	where	(n < 10)	
+)
+select	cte_1.n as n
+from	cte_1 as cte_1
+";
+            Test("Direct Select with recursive query to generate sequence", q.Expression, expectedResult);
+        }
+
+        [TestMethod]
+        public void Direct_Select_with_recursive_query_generate_missing_dates()
+        {
+            var start = new DateTime(2024, 1, 1);
+            var end = new DateTime(2024, 1, 31);
+            var days = (end - start).Days;
+
+            var dateSequence = dbc.Select(() => new { DayOffset = 0 })
+                                    .RecursiveUnion(anchor =>
+                                        anchor
+                                            .Where(x => x.DayOffset < days)
+                                            .Select(x => new { DayOffset = x.DayOffset + 1 })
+                                    )
+                                    .Select(x => new { Date = start.AddDays(x.DayOffset) });
+
+            var invoices = new Queryable<Invoice>(this.dbc);
+            var q = from date in dateSequence
+                    join invoice in invoices on date.Date equals invoice.InvoiceDate into invoiceGroup
+                    select new { date.Date, InvoiceCount = invoiceGroup.Count(), TotalSales = invoiceGroup.SelectMany(x => x.NavLines).Sum(y => y.LineTotal) };
+
+            string? expectedResult = @"
+with cte_1 as 
+(	
+	select	0 as DayOffset	
+		
+	union all	
+	select	(a_3.DayOffset + 1) as DayOffset	
+	from	cte_1 as a_3	
+	where	(DayOffset < 30)	
+)
+select	a_2.Date as Date, (
+	select	Count(1) as Col1
+	from	Invoice as a_4
+	where	(a_2.Date = a_4.InvoiceDate)
+) as InvoiceCount, (
+	select	Sum(NavLines_5.LineTotal) as Col1
+	from	Invoice as a_4
+		inner join InvoiceDetail as NavLines_5 on (a_4.RowId = NavLines_5.InvoiceId)
+	where	(a_2.Date = a_4.InvoiceDate)
+) as TotalSales
+from	(
+	select	dateadd(day, cte_1.DayOffset, '2024-01-01 00:00:00') as Date
+	from	cte_1 as cte_1
+) as a_2
+";
+            Test("Direct Select with recursive query to generate missing dates", q.Expression, expectedResult);
+        }
     }
 }

--- a/src/Atis.LinqToSql/Abstractions/ISqlExpressionFactory.cs
+++ b/src/Atis.LinqToSql/Abstractions/ISqlExpressionFactory.cs
@@ -34,6 +34,7 @@ namespace Atis.LinqToSql.Abstractions
         SqlQueryExpression CreateCteQuery(Guid cteAlias, SqlQueryExpression anchorQuery);
         SqlQueryExpression CreateQueryFromDataSources(IEnumerable<SqlDataSourceExpression> dataSourceList);
         SqlQueryExpression CreateQueryFromDataSource(SqlDataSourceExpression sqlDataSourceExpression);
+        SqlQueryExpression CreateQueryFromSelect(SqlExpression select);
         SqlSelectedCollectionExpression CreateSelectedCollection(SqlExpression collectionSource, SqlExpression[] collection);
         SqlTableExpression CreateTable(string tableName, TableColumn[] tableColumns);
         SqlUpdateExpression CreateUpdate(SqlQueryExpression sqlQuery, SqlDataSourceExpression selectedDataSource, string[] columnNames, SqlExpression[] values);
@@ -45,5 +46,8 @@ namespace Atis.LinqToSql.Abstractions
         SqlDataSourceExpression CreateDataSourceForCteQuery(Guid cteAlias, SqlQueryExpression cteSource);
         SqlColumnExpression CreateScalarColumn(SqlExpression columnExpression, string columnAlias, ModelPath modelPath);
         SqlInValuesExpression CreateInValuesExpression(SqlExpression expression, SqlExpression values);
+        SqlQueryExpression CreateEmptySqlQuery();
+        SqlQuerySourceExpression CreateSubQuery(SqlQueryExpression sqlQuery);
+        SqlKeywordExpression CreateKeyword(string keyword);
     }
 }

--- a/src/Atis.LinqToSql/ExpressionConverters/DateFunctionsConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/DateFunctionsConverter.cs
@@ -1,0 +1,78 @@
+﻿using Atis.Expressions;
+using Atis.LinqToSql.Abstractions;
+using Atis.LinqToSql.SqlExpressions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Linq;
+using System.Text;
+
+namespace Atis.LinqToSql.ExpressionConverters
+{
+    public class DateFunctionsConverterFactory : LinqToSqlExpressionConverterFactoryBase<MethodCallExpression>
+    {
+        private static readonly string[] SupportedMethods = new[]
+        {
+            nameof(DateTime.AddDays),
+            nameof(DateTime.AddMonths),
+            nameof(DateTime.AddYears)
+        };
+
+        public DateFunctionsConverterFactory(IConversionContext context) : base(context) { }
+
+        public override bool TryCreate(Expression expression, ExpressionConverterBase<Expression, SqlExpression>[] converterStack, out ExpressionConverterBase<Expression, SqlExpression> converter)
+        {
+            if (expression is MethodCallExpression methodCall &&
+                methodCall.Method.DeclaringType == typeof(DateTime) &&
+                SupportedMethods.Contains(methodCall.Method.Name))
+            {
+                converter = new DateFunctionsConverter(this.Context, methodCall, converterStack);
+                return true;
+            }
+
+            converter = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     <para>
+    ///         Converts supported DateTime instance methods like AddDays, AddMonths, AddYears into SQL DATEADD function calls.
+    ///     </para>
+    /// </summary>
+    public class DateFunctionsConverter : LinqToSqlExpressionConverterBase<MethodCallExpression>
+    {
+        public DateFunctionsConverter(
+            IConversionContext context,
+            MethodCallExpression expression,
+            ExpressionConverterBase<Expression, SqlExpression>[] converterStack)
+            : base(context, expression, converterStack)
+        {
+        }
+
+        public override SqlExpression Convert(SqlExpression[] convertedChildren)
+        {
+            var methodName = this.Expression.Method.Name;
+            var dateExpr = convertedChildren[0];      // e.g., DateTime instance
+            var argExpr = convertedChildren[1];       // e.g., number of days/months/years
+
+            if (methodName == nameof(DateTime.AddDays))
+                return CreateDateAdd("day", dateExpr, argExpr);
+
+            if (methodName == nameof(DateTime.AddMonths))
+                return CreateDateAdd("month", dateExpr, argExpr);
+
+            if (methodName == nameof(DateTime.AddYears))
+                return CreateDateAdd("year", dateExpr, argExpr);
+
+            throw new NotSupportedException("Unsupported DateTime method: " + methodName);
+        }
+
+        private SqlFunctionCallExpression CreateDateAdd(string part, SqlExpression dateExpr, SqlExpression amountExpr)
+        {
+            return this.SqlFactory.CreateFunctionCall("dateadd",
+                new[] { this.SqlFactory.CreateKeyword(part), amountExpr, dateExpr });
+        }
+    }
+
+}

--- a/src/Atis.LinqToSql/ExpressionConverters/JoinQueryMethodExpressionConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/JoinQueryMethodExpressionConverter.cs
@@ -162,7 +162,7 @@ namespace Atis.LinqToSql.ExpressionConverters
 
                 if (updatedMapping.CurrentDataSourceMemberInfo == null)
                 {
-                    var dataSourceWithModelPath = this.SourceQuery.AllDataSources
+                    var dataSourceWithModelPath = this.SourceQuery.AllQuerySources
                                                                     .Where(x => !x.ModelPath.IsEmpty)
                                                                     .Select(x => new { Ds = x, DsModelPath = x.ModelPath.GetLastElement() })
                                                                     .ToDictionary(x => x.DsModelPath, x => x.Ds);
@@ -176,7 +176,7 @@ namespace Atis.LinqToSql.ExpressionConverters
                 }
                 else
                 {
-                    foreach (var ds in this.SourceQuery.AllDataSources)
+                    foreach (var ds in this.SourceQuery.AllQuerySources)
                     {
                         if (ds != this.newJoinedDataSource)
                         {

--- a/src/Atis.LinqToSql/ExpressionConverters/ParameterExpressionConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/ParameterExpressionConverter.cs
@@ -88,6 +88,13 @@ namespace Atis.LinqToSql.ExpressionConverters
             // isLeafNode is true when the ParameterExpression is selected alone
             if (!(sqlExpression is SqlQueryExpression || sqlExpression is SqlDataSourceExpression))
                 throw new InvalidOperationException($"'{sqlExpression}' is neither SqlQueryExpression nor SqlDataSourceExpression");
+
+            if (sqlExpression is SqlSubQueryExpression subQuery)
+            {
+                sqlExpression = subQuery.CreateCopy();
+                return sqlExpression;
+            }
+
             SqlExpression result;
             if (isLeafNode)
             {

--- a/src/Atis.LinqToSql/ExpressionConverters/SelectManyQueryMethodExpressionConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/SelectManyQueryMethodExpressionConverter.cs
@@ -282,7 +282,7 @@ namespace Atis.LinqToSql.ExpressionConverters
                 var lastDs = sqlQuery.DataSources.Last();
                 if (updatedMap.CurrentDataSourceMemberInfo != null)
                 {
-                    foreach (var ds in this.SourceQuery.AllDataSources)
+                    foreach (var ds in this.SourceQuery.AllQuerySources)
                     {
                         if (ds != lastDs)
                         {

--- a/src/Atis.LinqToSql/ExpressionConverters/SelectQueryMethodExpressionConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/SelectQueryMethodExpressionConverter.cs
@@ -27,7 +27,10 @@ namespace Atis.LinqToSql.ExpressionConverters
         /// <inheritdoc />
         protected override bool IsQueryMethodCall(MethodCallExpression methodCallExpression)
         {
-            return methodCallExpression.Method.Name == nameof(Queryable.Select);
+            return methodCallExpression.Method.Name == nameof(Queryable.Select)
+                    &&
+                    (methodCallExpression.Method.DeclaringType == typeof(Queryable) ||
+                        methodCallExpression.Method.DeclaringType == typeof(Enumerable));
         }
 
         /// <inheritdoc />

--- a/src/Atis.LinqToSql/ExpressionConverters/StandaloneSelectQueryMethodExpressionConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/StandaloneSelectQueryMethodExpressionConverter.cs
@@ -1,0 +1,56 @@
+﻿using Atis.Expressions;
+using Atis.LinqToSql.Abstractions;
+using Atis.LinqToSql.SqlExpressions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Atis.LinqToSql.ExpressionConverters
+{
+    public class StandaloneSelectQueryMethodExpressionConverterFactory : LinqToSqlExpressionConverterFactoryBase<MethodCallExpression>
+    {
+        public StandaloneSelectQueryMethodExpressionConverterFactory(IConversionContext context) : base(context)
+        {
+        }
+        public override bool TryCreate(Expression expression, ExpressionConverterBase<Expression, SqlExpression>[] converterStack, out ExpressionConverterBase<Expression, SqlExpression> converter)
+        {
+            if (expression is MethodCallExpression methodCallExpression &&
+                    methodCallExpression.Method.Name == nameof(QueryExtensions.Select) &&
+                    methodCallExpression.Method.DeclaringType == typeof(QueryExtensions))
+            {
+                converter = new StandaloneSelectQueryMethodExpressionConverter(this.Context, methodCallExpression, converterStack);
+                return true;
+            }
+            converter = null;
+            return false;
+        }
+    }
+
+    public class StandaloneSelectQueryMethodExpressionConverter : LinqToSqlExpressionConverterBase<MethodCallExpression>
+    {
+        public StandaloneSelectQueryMethodExpressionConverter(IConversionContext context, MethodCallExpression expression, ExpressionConverterBase<Expression, SqlExpression>[] converterStack)
+            : base(context, expression, converterStack)
+        {
+        }
+
+        public override bool TryOverrideChildConversion(Expression sourceExpression, out SqlExpression convertedExpression)
+        {
+            if (sourceExpression == this.Expression.Arguments[0])
+{
+                convertedExpression = this.SqlFactory.CreateLiteral("dummy");
+                return true;
+            }
+            convertedExpression = null;
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override SqlExpression Convert(SqlExpression[] convertedChildren)
+        {
+            // convertedChildren[0] is dummy (for IQueryProvider)
+            var sqlQuery = this.SqlFactory.CreateQueryFromSelect(convertedChildren[1]);
+            return sqlQuery;
+        }
+    }
+}

--- a/src/Atis.LinqToSql/ExpressionConverters/StandardJoinQueryMethodExpressionConverter.cs
+++ b/src/Atis.LinqToSql/ExpressionConverters/StandardJoinQueryMethodExpressionConverter.cs
@@ -119,7 +119,10 @@ namespace Atis.LinqToSql.ExpressionConverters
                 }
                 else
                 {
-                    querySource = otherDataSqlQuery;
+                    if (this.UseSubQueryDataSource)
+                        querySource = this.SqlFactory.CreateSubQuery(otherDataSqlQuery);
+                    else
+                        querySource = otherDataSqlQuery;
                 }
 
                 if (this.UseSubQueryDataSource)
@@ -219,7 +222,7 @@ namespace Atis.LinqToSql.ExpressionConverters
             {
                 if (this.HasDefaultProjection())
                 {
-                    this.UpdateModelMaps(sqlQuery.AllDataSources);
+                    this.UpdateModelMaps(sqlQuery.AllQuerySources);
                 }
                 else
                 {

--- a/src/Atis.LinqToSql/LinqToSqlExpressionConverterProvider.cs
+++ b/src/Atis.LinqToSql/LinqToSqlExpressionConverterProvider.cs
@@ -65,6 +65,8 @@ namespace Atis.LinqToSql
                 new DeleteQueryMethodExpressionConverterFactory(context),
                 new InValuesExpressionConverterFactory(context),
                 new NewArrayExpressionConverterFactory(context),
+                new StandaloneSelectQueryMethodExpressionConverterFactory(context),
+                new DateFunctionsConverterFactory(context), 
             };
             this.Factories.AddRange(defaultConverters);
         }

--- a/src/Atis.LinqToSql/PostProcessors/CteCrossJoinPostprocessor.cs
+++ b/src/Atis.LinqToSql/PostProcessors/CteCrossJoinPostprocessor.cs
@@ -80,7 +80,7 @@ namespace Atis.LinqToSql.Postprocessors
                 for (var i = 0; i < dataSourcesToAdd.Length; i++)
                 {
                     var cteUsage = dataSourcesToAdd[i];
-                    if (!(sqlQuery.AllDataSources.Any(x => x.DataSourceAlias == cteUsage.NewCteReferenceToAdd.DataSourceAlias)))
+                    if (!(sqlQuery.AllQuerySources.Any(x => x.DataSourceAlias == cteUsage.NewCteReferenceToAdd.DataSourceAlias)))
                     {
                         sqlQuery.AddDataSource(cteUsage.NewCteReferenceToAdd);
                     }

--- a/src/Atis.LinqToSql/QueryExtensions.cs
+++ b/src/Atis.LinqToSql/QueryExtensions.cs
@@ -525,5 +525,21 @@ namespace Atis.LinqToSql
                     query.Expression, Expression.Quote(tableSelection), Expression.Quote(predicate)));
             return query.Provider.Execute<int>(q.Expression);
         }
+
+        public static IQueryable<R> Select<R>(this IQueryProvider db, Expression<Func<R>> selector)
+        {
+            if (db is null)
+                throw new ArgumentNullException(nameof(db));
+            if (selector is null)
+                throw new ArgumentNullException(nameof(selector));
+
+            return db.CreateQuery<R>(
+                Expression.Call(
+                    typeof(QueryExtensions),
+                    nameof(Select),
+                    new Type[] { typeof(R) },
+                    Expression.Constant(db),
+                    selector));
+        }
     }
 }

--- a/src/Atis.LinqToSql/Services/SqlExpressionFactory.cs
+++ b/src/Atis.LinqToSql/Services/SqlExpressionFactory.cs
@@ -143,6 +143,11 @@ namespace Atis.LinqToSql.Services
             return new SqlQueryExpression(dataSource, this);
         }
 
+        public virtual SqlQueryExpression CreateQueryFromSelect(SqlExpression select)
+        {
+            return new SqlQueryExpression((SqlExpression)select, this);
+        }
+
         public virtual SqlSelectedCollectionExpression CreateSelectedCollection(SqlExpression collectionSource, SqlExpression[] collection)
         {
             return new SqlSelectedCollectionExpression(collectionSource, collection);
@@ -196,6 +201,21 @@ namespace Atis.LinqToSql.Services
         public virtual SqlInValuesExpression CreateInValuesExpression(SqlExpression expression, SqlExpression values)
         {
             return new SqlInValuesExpression(expression, new[] { values });
+        }
+
+        public SqlQueryExpression CreateEmptySqlQuery()
+        {
+            return new SqlQueryExpression(this);
+        }
+
+        public SqlQuerySourceExpression CreateSubQuery(SqlQueryExpression sqlQuery)
+        {
+            return new SqlSubQueryExpression(sqlQuery);
+        }
+
+        public SqlKeywordExpression CreateKeyword(string keyword)
+        {
+            return new SqlKeywordExpression(keyword);
         }
     }
 }

--- a/src/Atis.LinqToSql/SqlExpressions/SqlDeleteExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlDeleteExpression.cs
@@ -9,7 +9,7 @@ namespace Atis.LinqToSql.SqlExpressions
         {
             this.SqlQuery = sqlQuery ?? throw new ArgumentNullException(nameof(sqlQuery));
             this.DeletingDataSource = deletingDataSource ?? throw new ArgumentNullException(nameof(deletingDataSource));
-            if (!this.SqlQuery.AllDataSources.Where(x => x == deletingDataSource).Any())
+            if (!this.SqlQuery.AllQuerySources.Where(x => x == deletingDataSource).Any())
                 throw new ArgumentException("The deleting data source must be part of the query.", nameof(deletingDataSource));
             if (!(deletingDataSource.QuerySource is SqlTableExpression))
                 throw new ArgumentException("The deleting data source must be a table.", nameof(deletingDataSource));

--- a/src/Atis.LinqToSql/SqlExpressions/SqlExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlExpression.cs
@@ -100,7 +100,8 @@ namespace Atis.LinqToSql.SqlExpressions
         Not,
         CteDataSource,
         SubQueryColumn,
-        In
+        In,
+        Keyword
     }
 
 

--- a/src/Atis.LinqToSql/SqlExpressions/SqlKeywordExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlKeywordExpression.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Atis.LinqToSql.SqlExpressions
+{
+    public class SqlKeywordExpression : SqlExpression
+    {
+        public string Keyword { get; }
+
+        public SqlKeywordExpression(string keyword)
+        {
+            Keyword = keyword ?? throw new ArgumentNullException(nameof(keyword));
+        }
+
+        public override SqlExpressionType NodeType => SqlExpressionType.Keyword;
+
+        public override string ToString()
+        {
+            return Keyword;
+        }
+    }
+}

--- a/src/Atis.LinqToSql/SqlExpressions/SqlQueryExpression.CteDataSourceSearchVisitor.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlQueryExpression.CteDataSourceSearchVisitor.cs
@@ -61,7 +61,7 @@ public partial class SqlQueryExpression
             private void FindOuterDataSource(Guid dataSourceAlias)
             {
                 if (this.cteDataSource.Count > 0)
-                    if (this.sourceQuery.AllDataSources.Any(x => x.DataSourceAlias == dataSourceAlias))
+                    if (this.sourceQuery.AllQuerySources.Any(x => x.DataSourceAlias == dataSourceAlias))
                         this.HasOuterDataSource = true;
                         //throw new InvalidOperationException($"Outer data source is being used in a CTE Query.");
             }

--- a/src/Atis.LinqToSql/SqlExpressions/SqlQueryExpression.OuterDataSourceUsageInCteValidator.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlQueryExpression.OuterDataSourceUsageInCteValidator.cs
@@ -48,7 +48,7 @@ public partial class SqlQueryExpression
             private void ValidateOuterDataSourceUsageInCte(Guid dataSourceAlias)
             {
                 if (this.cteDataSource.Count > 0)
-                    if (this.sourceQuery.AllDataSources.Any(x => x.DataSourceAlias == dataSourceAlias))
+                    if (this.sourceQuery.AllQuerySources.Any(x => x.DataSourceAlias == dataSourceAlias))
                         throw new InvalidOperationException($"Outer data source is being used in a CTE Query.");
             }
         }

--- a/src/Atis.LinqToSql/SqlExpressions/SqlSubQueryExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlSubQueryExpression.cs
@@ -1,0 +1,23 @@
+﻿using Atis.LinqToSql.Abstractions;
+using Atis.LinqToSql.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Atis.LinqToSql.SqlExpressions
+{
+    public class SqlSubQueryExpression : SqlQueryExpression
+    {
+        public SqlSubQueryExpression(SqlQueryExpression sqlQuery) : base(sqlQuery.SqlFactory)
+        {
+            Copy(sqlQuery, this);
+        }
+
+        public override string ToString()
+        {
+            var dataSourcesAliases = string.Join(", ", this.AllQuerySources.Select(x => DebugAliasGenerator.GetAlias(x)));
+            return $"{(this.IsCte ? "Cte-Sub-Query" : "Sub-Query")}: {dataSourcesAliases}";
+        }
+    }
+}

--- a/src/Atis.LinqToSql/SqlExpressions/SqlUpdateExpression.cs
+++ b/src/Atis.LinqToSql/SqlExpressions/SqlUpdateExpression.cs
@@ -15,7 +15,7 @@ namespace Atis.LinqToSql.SqlExpressions
                 throw new ArgumentException("At least one column must be specified.", nameof(columns));
             if (columns.Length != values.Length)
                 throw new ArgumentException("The number of columns must match the number of values.", nameof(columns));
-            if (!this.SqlQuery.AllDataSources.Where(x => x == updatingDataSource).Any())
+            if (!this.SqlQuery.AllQuerySources.Where(x => x == updatingDataSource).Any())
                 throw new ArgumentException("The updating data source must be part of the query.", nameof(updatingDataSource));
             if (!(updatingDataSource.QuerySource is SqlTableExpression))
                 throw new ArgumentException("The updating data source must be a table.", nameof(updatingDataSource));


### PR DESCRIPTION
1. Added `Select` Query Extension method to create a query without From, useful in creating sequences directly in SQL through recursive query
2. Added Sub-Query detection so that if Lambda Parameter is resolved to `SqlSubQueryExpression` we'll create the copy when converting Lambda Parameter.
3. Added a few Date Functions
4. Added `SqlKeywordExpression`, helpful in the places where Sql Fragment needs to be placed during translation.